### PR TITLE
Fix build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,11 +94,13 @@ include(tbb)
 # Add your project files
 # Create an executable
 file(GLOB SRCFILES  
-    include/*.h
-    source/*.cpp
-    source/*.h
-    *.cpp)
+    main.cpp)
+
+file(GLOB MC33_SRCFILES
+    source/libMC33++.cpp)
     
+
+add_library(MC33++ STATIC ${MC33_SRCFILES})
 add_executable(
         ${PROJECT_NAME}_bin
         ${SRCFILES}
@@ -109,6 +111,7 @@ set_target_properties(${PROJECT_NAME}_bin PROPERTIES CXX_STANDARD_REQUIRED ON)
 
 # Link settings
 target_link_libraries( ${PROJECT_NAME}_bin 
+        MC33++
         polyscope 
         TBB::tbb 
         tbb_static 

--- a/main.cpp
+++ b/main.cpp
@@ -1,8 +1,8 @@
-#include "source/MC33.cpp"
+//#include "source/MC33.cpp"
 //#include "source/grid3d.cpp"
 //#include "source/surface.cpp"
 
-//#include "include/MC33.h"
+#include "include/MC33.h"
 
 #include <iostream>
 #include <igl/read_triangle_mesh.h>

--- a/source/libMC33++.cpp
+++ b/source/libMC33++.cpp
@@ -1,0 +1,29 @@
+/*
+	File: libMC33++.cpp
+	Programmed by: David Vega
+	August 2019
+	August 2020
+	April 2021
+	December 2021
+	Only this file must be included in a project to compile the MC33 library
+*/
+
+#define compiling_libMC33
+/********************************CUSTOMIZING**********************************/
+//The following line can be only changed before compiling the library:
+//#define MC_Normal_neg // the front and back surfaces are exchanged.
+/*****************************************************************************/
+
+#include "../include/MC33.h"
+
+#ifndef GRD_orthogonal
+extern void (*multAbf)(const double (*)[3], MC33_real *, MC33_real *, int);
+extern void (*multAb)(const double (*)[3], double *, double *, int);
+extern void (*mult_Abf)(const double (*)[3], MC33_real *, MC33_real *, int);
+extern void (*mult_TSAbf)(const double (*)[3], MC33_real *, MC33_real *, int);
+#endif
+
+#include "grid3d.cpp"
+#include "surface.cpp"
+#include "MC33.cpp"
+


### PR DESCRIPTION
Fixes build by doing three things:
  1. Reintroduce the libMC33++.cpp file, which is used to build the static library properly
  2. Modify CMakeLists.txt to build the library separately using an add_library call, targeted at the libMC33++.cpp file (which is how the source repo builds the static library)
  3. Modify main.cpp to include the header instead of the source files.